### PR TITLE
Fixed Permission Denied error when running on Docker

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,7 +4,9 @@ WORKDIR /usr/src/app/client
 
 COPY package*.json ./
 
-RUN npm install
+RUN mkdir .next && npm install
+
+RUN chown -Rh node:node .next node_modules
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3.5'
 services:
   client:
     container_name: client
+    user: node
     build:
       context: ./client
     ports:


### PR DESCRIPTION
Fixes #30

Turns out the [volume mounts](https://github.com/KanaryStack/aliascheck/blob/3f20eaa3aed83626d17d846c0f955a16e3f24737/docker-compose.yml#L12-L13) are [done as root](https://github.com/docker/compose/issues/3270). I `chown`ed the `.next` and `node_modules` folders and this fixes the problem.
